### PR TITLE
Add property type group mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,20 @@ On the homepage, enter a natural-language description of the type of property yo
 - `OPENAI_API_KEY` – your OpenAI API key used to generate search criteria
 
 A sample `.env.local.example` file is included.
+
+## Property Type Mapping
+
+The application maps common property type keywords to the numeric `PropertyTypeGroupID`
+used by realtor.ca. The following table lists some examples:
+
+| Property type keyword | PropertyTypeGroupID |
+| -------------------- | ------------------ |
+| house, detached, townhouse, condo, condominium, apartment | `1` |
+| vacant land, land | `2` |
+| farm, agricultural | `3` |
+| office | `4` |
+| retail | `5` |
+| industrial | `6` |
+| hospitality | `7` |
+| multi-family | `8` |
+| other | `9` |

--- a/src/components/PropertySearch.tsx
+++ b/src/components/PropertySearch.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { getPropertyTypeGroupId } from '../utils/propertyType';
 
 interface Criteria {
   location?: string;
@@ -25,7 +26,8 @@ export default function PropertySearch() {
     const data: Criteria = await res.json();
     const params = new URLSearchParams();
     if (data.location) params.append('GeoName', data.location);
-    if (data.propertyType) params.append('PropertyTypeGroupID', data.propertyType);
+    const typeId = getPropertyTypeGroupId(data.propertyType);
+    if (typeId) params.append('PropertyTypeGroupID', typeId);
     if (data.minPrice) params.append('MinPrice', String(data.minPrice));
     if (data.maxPrice) params.append('MaxPrice', String(data.maxPrice));
     if (data.beds) params.append('BedsMin', String(data.beds));

--- a/src/utils/propertyType.ts
+++ b/src/utils/propertyType.ts
@@ -1,0 +1,24 @@
+export const propertyTypeGroupMap: Record<string, string> = {
+  house: '1',
+  detached: '1',
+  townhouse: '1',
+  condo: '1',
+  condominium: '1',
+  apartment: '1',
+  "vacant land": '2',
+  land: '2',
+  farm: '3',
+  agricultural: '3',
+  office: '4',
+  retail: '5',
+  industrial: '6',
+  hospitality: '7',
+  "multi-family": '8',
+  other: '9',
+};
+
+export function getPropertyTypeGroupId(type: string | undefined): string | undefined {
+  if (!type) return undefined;
+  const key = type.trim().toLowerCase();
+  return propertyTypeGroupMap[key];
+}


### PR DESCRIPTION
## Summary
- create `getPropertyTypeGroupId` helper
- use helper in `PropertySearch` when building the realtor.ca URL
- document property type ID mapping in README

## Testing
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685dd4015178832e82db49c1760783d2