### PR TITLE
Add Jest tests for API and PropertySearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ This project is a minimal Next.js application that converts natural-language pro
    ```
    Open [http://localhost:3000](http://localhost:3000) to view the app.
 
+4. **Run tests**
+   ```bash
+   yarn test
+   ```
+
 ## Usage
 
 On the homepage, enter a natural-language description of the type of property you are looking for. After submitting, a link appears that opens realtor.ca with the criteria extracted from your description.

--- a/__tests__/PropertySearch.test.tsx
+++ b/__tests__/PropertySearch.test.tsx
@@ -1,0 +1,49 @@
+import PropertySearch from '../src/components/PropertySearch';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ location: 'Toronto', beds: 3 }),
+  }) as any;
+});
+
+afterEach(() => {
+  (global.fetch as jest.Mock).mockReset();
+});
+
+test('generates url with location and beds', async () => {
+  render(<PropertySearch />);
+  fireEvent.change(screen.getByPlaceholderText(/describe the property/i), {
+    target: { value: 'something' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /search/i }));
+
+  const link = await screen.findByRole('link', { name: /open search results/i });
+  expect(link.getAttribute('href')).toBe(
+    'https://www.realtor.ca/map#GeoName=Toronto&BedsMin=3'
+  );
+});
+
+test('generates url with multiple criteria', async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      location: 'Vancouver',
+      propertyType: '2',
+      minPrice: 100,
+      maxPrice: 200,
+      beds: 2,
+    }),
+  });
+  render(<PropertySearch />);
+  fireEvent.change(screen.getByPlaceholderText(/describe the property/i), {
+    target: { value: 'another' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /search/i }));
+
+  const link = await screen.findByRole('link', { name: /open search results/i });
+  expect(link.getAttribute('href')).toBe(
+    'https://www.realtor.ca/map#GeoName=Vancouver&PropertyTypeGroupID=2&MinPrice=100&MaxPrice=200&BedsMin=2'
+  );
+});

--- a/__tests__/route.test.ts
+++ b/__tests__/route.test.ts
@@ -1,0 +1,41 @@
+import { POST, criteriaSchema } from '../src/app/api/parse/route';
+import { generateObject } from 'ai';
+
+jest.mock('ai');
+
+describe('criteriaSchema', () => {
+  it('parses valid data', () => {
+    const data = criteriaSchema.parse({ location: 'Toronto', minPrice: 100 });
+    expect(data).toEqual({ location: 'Toronto', minPrice: 100 });
+  });
+
+  it('rejects invalid data', () => {
+    const result = criteriaSchema.safeParse({ minPrice: 'bad' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('POST', () => {
+  const mockedGenerate = generateObject as jest.Mock;
+
+  beforeEach(() => {
+    mockedGenerate.mockResolvedValue({ object: { location: 'Calgary' } });
+  });
+
+  afterEach(() => {
+    mockedGenerate.mockReset();
+  });
+
+  it('returns extracted criteria', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ description: 'any' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(mockedGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ schema: criteriaSchema })
+    );
+    expect(data).toEqual({ location: 'Calgary' });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  testMatch: ['**/__tests__/**/*.test.ts?(x)'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "@ai-sdk/openai": "latest",
@@ -76,6 +77,11 @@
     "@types/react-dom": "^19",
     "eslint": "^8.0.0",
     "eslint-config-next": "^15.2.4",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.2.0",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"

--- a/src/app/api/parse/route.ts
+++ b/src/app/api/parse/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { generateObject } from 'ai';
 import { openai } from '@ai-sdk/openai';
 
-const criteriaSchema = z.object({
+export const criteriaSchema = z.object({
   location: z.string().optional().describe('City or area'),
   propertyType: z.string().optional().describe('Type of property'),
   minPrice: z.number().optional().describe('Minimum price in CAD'),


### PR DESCRIPTION
## Summary
- export `criteriaSchema` for testing
- add Jest configuration and setup
- add unit tests for parse API route
- add component tests for PropertySearch URL generation
- document how to run tests

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685dd40203e8832eb71ede61918703b1